### PR TITLE
feat: migrate Apollo Client 3 to 4

### DIFF
--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,6 +1,5 @@
-'use client';
-
-import { useApolloClient } from '@apollo/client';
+'use client';;
+import { useApolloClient } from "@apollo/client/react";
 import { useRouter } from 'next/navigation';
 import CustomLink from '../../components/common/CustomLink';
 import Form from '../../components/forms/form';

--- a/app/register/page.tsx
+++ b/app/register/page.tsx
@@ -1,6 +1,5 @@
-'use client';
-
-import { useApolloClient } from '@apollo/client';
+'use client';;
+import { useApolloClient } from "@apollo/client/react";
 import { useRouter } from 'next/navigation';
 import CustomLink from '../../components/common/CustomLink';
 import Form from '../../components/forms/form';

--- a/app/settings/page.tsx
+++ b/app/settings/page.tsx
@@ -1,6 +1,5 @@
-'use client';
-
-import { useApolloClient } from '@apollo/client';
+'use client';;
+import { useApolloClient } from "@apollo/client/react";
 import CustomButton from '../../components/common/CustomButton';
 import Form from '../../components/forms/form';
 import FormTextarea from '../../components/forms/form-teextarea';

--- a/components/article-list/ArticlesViewer.tsx
+++ b/components/article-list/ArticlesViewer.tsx
@@ -24,25 +24,33 @@ export default function ArticlesViewer({ tabs, isFeedQuery, queryFilter }: Artic
 
   const fallbackMessage = 'Could not load articles... ';
   const noArticlesMessage = 'No articles are here... yet';
-  const [loadArticles, { data: articlesData, fetchMore, networkStatus }] = useArticlesLazyQuery({
+  const [loadArticles, { data: articlesData, error: articlesError, fetchMore, networkStatus }] = useArticlesLazyQuery({
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
     notifyOnNetworkStatusChange: true,
-    onError: () => error({ content: fallbackMessage, mode: 'alert' }),
-    onCompleted: (data) => {
-      if (data && data.articles.length === 0) info({ content: noArticlesMessage, mode: 'alert' });
-    },
   });
 
-  const [loadFeed, { data: feedData, fetchMore: fetchMoreFeed, networkStatus: feedNetworkStatus }] = useFeedLazyQuery({
+  const [loadFeed, { data: feedData, error: feedError, fetchMore: fetchMoreFeed, networkStatus: feedNetworkStatus }] = useFeedLazyQuery({
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
     notifyOnNetworkStatusChange: true,
-    onError: () => error({ content: fallbackMessage, mode: 'alert' }),
-    onCompleted: (data) => {
-      if (data && data.feed.length === 0) info({ content: noArticlesMessage, mode: 'alert' });
-    },
   });
+
+  useEffect(() => {
+    if (articlesError) error({ content: fallbackMessage, mode: 'alert' });
+  }, [articlesError]);
+
+  useEffect(() => {
+    if (feedError) error({ content: fallbackMessage, mode: 'alert' });
+  }, [feedError]);
+
+  useEffect(() => {
+    if (articlesData && articlesData.articles.length === 0) info({ content: noArticlesMessage, mode: 'alert' });
+  }, [articlesData]);
+
+  useEffect(() => {
+    if (feedData && feedData.feed.length === 0) info({ content: noArticlesMessage, mode: 'alert' });
+  }, [feedData]);
 
   useEffect(() => {
     const loadData = async () => {
@@ -78,12 +86,12 @@ export default function ArticlesViewer({ tabs, isFeedQuery, queryFilter }: Artic
         offset > 0 ? setBottomLoading(true) : setTopLoading(true);
         const { data } = await fetchMoreFeed({ variables: fetchMoreQueryFilter });
         offset > 0 ? setBottomLoading(false) : setTopLoading(false);
-        offset > 0 ? setBottomFetchedSize(data.feed.length) : setTopFetchedSize(data.feed.length);
+        offset > 0 ? setBottomFetchedSize(data?.feed.length ?? 0) : setTopFetchedSize(data?.feed.length ?? 0);
       } else {
         offset > 0 ? setBottomLoading(true) : setTopLoading(true);
         const { data } = await fetchMore({ variables: fetchMoreQueryFilter });
         offset > 0 ? setBottomLoading(false) : setTopLoading(false);
-        offset > 0 ? setBottomFetchedSize(data.articles.length) : setTopFetchedSize(data.articles.length);
+        offset > 0 ? setBottomFetchedSize(data?.articles.length ?? 0) : setTopFetchedSize(data?.articles.length ?? 0);
       }
     },
     [isFeedQuery, fetchMoreFeed, fetchMore, queryFilter]

--- a/components/article/CommentForm.tsx
+++ b/components/article/CommentForm.tsx
@@ -4,6 +4,7 @@ import {
   AuthUser,
   CommentInput,
   CommentsDocument,
+  CommentsQuery,
   useCreateCommentMutation,
 } from '../../generated/graphql';
 import { useMessageHandler } from '../../lib/hooks/use-message';
@@ -26,8 +27,8 @@ export default function CommentForm({
     update(cache, { data }) {
       if (data) {
         const newComment = data.createComment;
-        cache.updateQuery({ query: CommentsDocument, variables: { articleId: article.id } }, (data) => ({
-          comments: R.prepend(newComment, data.comments),
+        cache.updateQuery<CommentsQuery>({ query: CommentsDocument, variables: { articleId: article.id } }, (data) => ({
+          comments: R.prepend(newComment, data?.comments ?? []),
         }));
       }
     },

--- a/components/article/CommentSection.tsx
+++ b/components/article/CommentSection.tsx
@@ -1,5 +1,5 @@
 import { NetworkStatus } from '@apollo/client';
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { ArticleViewFragment, useCommentsQuery } from '../../generated/graphql';
 import { COMMENTS_PAGE_SIZE } from '../../lib/constants';
 import { useCurrentUser } from '../../lib/hooks/use-current-user';
@@ -16,16 +16,20 @@ export default function CommentSection({ article }: { article: ArticleViewFragme
 
   const fallbackMessage = 'Could not load comments... ';
   const noArticlesMessage = 'No comments here... yet';
-  const { data, fetchMore, networkStatus } = useCommentsQuery({
+  const { data, error: queryError, fetchMore, networkStatus } = useCommentsQuery({
     variables: { articleId: article.id, offset: 0, limit: COMMENTS_PAGE_SIZE },
     fetchPolicy: 'cache-and-network',
     nextFetchPolicy: 'cache-first',
     notifyOnNetworkStatusChange: true,
-    onError: () => error({ content: fallbackMessage, mode: 'toast' }),
-    onCompleted: (data) => {
-      if (data && data.comments.length === 0) info({ content: noArticlesMessage, mode: 'none' });
-    },
   });
+
+  useEffect(() => {
+    if (queryError) error({ content: fallbackMessage, mode: 'toast' });
+  }, [queryError]);
+
+  useEffect(() => {
+    if (data && data.comments.length === 0) info({ content: noArticlesMessage, mode: 'none' });
+  }, [data]);
 
   const comments = data?.comments;
   const last = comments && comments.length && comments[data.comments.length - 1].id;
@@ -38,7 +42,7 @@ export default function CommentSection({ article }: { article: ArticleViewFragme
       const { data } = await fetchMore({
         variables: { articleId: article.id, offset, cursor, limit: COMMENTS_PAGE_SIZE },
       });
-      setFetchedSize(data.comments.length);
+      setFetchedSize(data?.comments.length ?? 0);
     },
     [article, fetchMore]
   );

--- a/generated/graphql.ts
+++ b/generated/graphql.ts
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client';
-import * as Apollo from '@apollo/client';
+import * as Apollo from '../lib/apollo-shim';
 export type Maybe<T> = T | null;
 export type InputMaybe<T> = Maybe<T>;
 export type Exact<T extends { [key: string]: unknown }> = { [K in keyof T]: T[K] };

--- a/lib/apollo-shim.ts
+++ b/lib/apollo-shim.ts
@@ -1,0 +1,25 @@
+// Shim for Apollo Client 4 compatibility with graphql-codegen output.
+// In Apollo 4, hooks and hook types moved from @apollo/client to @apollo/client/react.
+export * from '@apollo/client';
+
+// Re-export hooks from @apollo/client/react (these were removed from @apollo/client in v4)
+export { useQuery, useMutation, useLazyQuery } from '@apollo/client/react';
+
+// Re-export hook option types
+export type {
+  QueryHookOptions,
+  LazyQueryHookOptions,
+  MutationHookOptions,
+  QueryResult,
+  MutationResult,
+} from '@apollo/client/react';
+
+// Types removed in Apollo Client 4 but still referenced by graphql-codegen output
+import type { OperationVariables } from '@apollo/client';
+
+export type MutationFunction<TData = any, TVariables extends OperationVariables = OperationVariables> = (
+  options?: any
+) => Promise<any>;
+
+export type BaseMutationOptions<TData = any, TVariables extends OperationVariables = OperationVariables> =
+  Record<string, any>;

--- a/lib/client/apollo-client.ts
+++ b/lib/client/apollo-client.ts
@@ -1,34 +1,38 @@
-import { ApolloClient, ApolloLink, createHttpLink } from '@apollo/client';
-import { onError } from '@apollo/client/link/error';
-import { createPersistedQueryLink } from '@apollo/client/link/persisted-queries';
+import { ApolloClient, ApolloLink, HttpLink } from '@apollo/client';
+import { ErrorLink } from '@apollo/client/link/error';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
+import { PersistedQueryLink } from '@apollo/client/link/persisted-queries';
 import { sha256 } from 'crypto-hash';
 import { cache } from '../cache';
 import { BASE_URL } from '../constants';
 
-export const cacheLink = createPersistedQueryLink({
+export const cacheLink = new PersistedQueryLink({
   sha256,
   useGETForHashedQueries: true,
 });
 
-export const httpLink = createHttpLink({
+export const httpLink = new HttpLink({
   uri: `${BASE_URL}/api`,
   credentials: 'same-origin',
 });
 
-export const errorLink = onError(({ graphQLErrors, networkError }) => {
+export const errorLink = new ErrorLink(({ error }) => {
   if (process.env.NODE_ENV === 'development') {
-    if (graphQLErrors) {
-      graphQLErrors.forEach(({ message, locations, path }) =>
+    if (CombinedGraphQLErrors.is(error)) {
+      error.errors.forEach(({ message, locations, path }) =>
         console.log(`[GraphQL error]: Message: ${message}, Location: ${locations}, Path: ${path}`)
       );
+    } else {
+      console.log(`[Network error]: ${error.message}`);
     }
-    if (networkError) console.log(`[Network error]: ${networkError.message}`);
   }
 });
 
 export default new ApolloClient({
   link: ApolloLink.from([errorLink, cacheLink, httpLink]),
-  connectToDevTools: process.env.NODE_ENV === 'development',
   cache,
   ssrMode: typeof window === 'undefined',
+  devtools: {
+    enabled: process.env.NODE_ENV === 'development',
+  },
 });

--- a/lib/hooks/use-apollo.tsx
+++ b/lib/hooks/use-apollo.tsx
@@ -1,4 +1,5 @@
-import { ApolloClient, ApolloLink, ApolloProvider } from '@apollo/client';
+import { ApolloClient, ApolloLink } from '@apollo/client';
+import { ApolloProvider } from '@apollo/client/react';
 import { setContext } from '@apollo/client/link/context';
 import React, { useMemo, useRef } from 'react';
 import { cache } from '../cache';
@@ -23,8 +24,10 @@ export function CustomApolloProvider({ children }: { children: React.ReactNode }
 
     return new ApolloClient({
       link: ApolloLink.from([errorLink, authLink, cacheLink, httpLink]),
-      connectToDevTools: process.env.NODE_ENV === 'development',
       cache,
+      devtools: {
+        enabled: process.env.NODE_ENV === 'development',
+      },
     });
   }, []);
 

--- a/lib/hooks/use-current-user.ts
+++ b/lib/hooks/use-current-user.ts
@@ -7,11 +7,13 @@ export function useCurrentUser() {
   const { token } = useToken();
   const { handleErrors } = useMessageHandler();
   const [loading, setLoading] = useState<boolean>(true);
-  const [loadCurrentUser, { data }] = useCurrentUserLazyQuery({
+  const [loadCurrentUser, { data, error: queryError }] = useCurrentUserLazyQuery({
     fetchPolicy: 'cache-first',
     nextFetchPolicy: 'cache-only',
-    onError: (err) => handleErrors({ err, mode: 'none' }),
   });
+  useEffect(() => {
+    if (queryError) handleErrors({ err: queryError, mode: 'none' });
+  }, [queryError, handleErrors]);
   useEffect(() => {
     const loadData = async () => {
       if (token) await loadCurrentUser();

--- a/lib/hooks/use-message.tsx
+++ b/lib/hooks/use-message.tsx
@@ -1,4 +1,6 @@
-import { ApolloError, useApolloClient } from '@apollo/client';
+import type { ErrorLike } from '@apollo/client';
+import { useApolloClient } from '@apollo/client/react';
+import { CombinedGraphQLErrors } from '@apollo/client/errors';
 import { usePathname, useSearchParams } from 'next/navigation';
 import { createContext, useCallback, useContext, useEffect, useState } from 'react';
 import { usePush } from './use-router-methods';
@@ -20,7 +22,7 @@ enum ServerErrorCode {
 
 interface MessageContext {
   message: Message | null;
-  handleErrors: ({ err, mode }: { err: ApolloError; mode: NotifyType }) => void;
+  handleErrors: ({ err, mode }: { err: ErrorLike; mode: NotifyType }) => void;
   dismiss: () => void;
   dismissing: boolean;
   success: (message: Pick<Message, 'content' | 'mode'>) => void;
@@ -86,25 +88,26 @@ function useProvideMessageHandler() {
   }, []);
 
   const handleErrors = useCallback(
-    ({ err: { graphQLErrors, networkError }, mode }: { err: ApolloError; mode: NotifyType }) => {
+    ({ err, mode }: { err: ErrorLike; mode: NotifyType }) => {
       const reset = async () => {
         handleChangeToken('');
         await client.resetStore();
         push('/login');
       };
 
-      if (graphQLErrors) {
-        for (let err of graphQLErrors) {
-          switch (err.extensions.code) {
+      if (CombinedGraphQLErrors.is(err)) {
+        for (const gqlErr of err.errors) {
+          switch ((gqlErr.extensions as Record<string, unknown>)?.code) {
             case ServerErrorCode.Unauthorized:
               if (token) reset(); // invalid token push to login
               break;
             default:
-              setMessage({ content: err.message, mode, type: 'error' });
+              setMessage({ content: gqlErr.message, mode, type: 'error' });
               break;
           }
         }
-        if (networkError) setMessage({ content: networkError.message, mode, type: 'error' });
+      } else {
+        setMessage({ content: err.message, mode, type: 'error' });
       }
     },
     [token, handleChangeToken, push, client]

--- a/lib/hooks/use-validation.ts
+++ b/lib/hooks/use-validation.ts
@@ -1,3 +1,4 @@
+import { useEffect } from 'react';
 import { AnySchema, object } from 'yup';
 import { AuthUser, useCheckEmailLazyQuery, useCheckUsernameLazyQuery, UserUpdateInput } from '../../generated/graphql';
 import { bio, email, image, password, username } from '../validation/schema';
@@ -5,12 +6,16 @@ import { useMessageHandler } from './use-message';
 
 export function useCheckUser(origin?: AuthUser) {
   const { handleErrors } = useMessageHandler();
-  const [checkUsername] = useCheckUsernameLazyQuery({
-    onError: (err) => handleErrors({ err, mode: 'alert' }),
-  });
-  const [checkEmail] = useCheckEmailLazyQuery({
-    onError: (err) => handleErrors({ err, mode: 'alert' }),
-  });
+  const [checkUsername, { error: usernameError }] = useCheckUsernameLazyQuery();
+  const [checkEmail, { error: emailError }] = useCheckEmailLazyQuery();
+
+  useEffect(() => {
+    if (usernameError) handleErrors({ err: usernameError, mode: 'alert' });
+  }, [usernameError, handleErrors]);
+
+  useEffect(() => {
+    if (emailError) handleErrors({ err: emailError, mode: 'alert' });
+  }, [emailError, handleErrors]);
 
   return object<Record<keyof UserUpdateInput, AnySchema>>({
     username: username.test('check-username', 'Username had been taken', async (value) => {

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
     "test:e2e:ui": "playwright test --ui"
   },
   "dependencies": {
-    "@apollo/client": "^3.6.9",
+    "@apollo/client": "4",
     "@graphql-codegen/cli": "^2.7.0",
     "@graphql-codegen/typescript": "2.6.0",
     "@graphql-codegen/typescript-operations": "2.4.3",
@@ -50,6 +50,7 @@
     "react": "19",
     "react-dom": "19",
     "react-hook-form": "^7.33.1",
+    "rxjs": "^7.8.2",
     "slug": "^5.3.0",
     "usehooks-ts": "^2.6.0",
     "yup": "^0.32.11"

--- a/yarn.lock
+++ b/yarn.lock
@@ -39,35 +39,34 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@apollo/client@npm:^3.6.9":
-  version: 3.6.9
-  resolution: "@apollo/client@npm:3.6.9::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2F%40apollo%2Fclient%2F-%2Fclient-3.6.9.tgz"
+"@apollo/client@npm:4":
+  version: 4.1.6
+  resolution: "@apollo/client@npm:4.1.6"
   dependencies:
     "@graphql-typed-document-node/core": ^3.1.1
-    "@wry/context": ^0.6.0
-    "@wry/equality": ^0.5.0
-    "@wry/trie": ^0.3.0
+    "@wry/caches": ^1.0.0
+    "@wry/equality": ^0.5.6
+    "@wry/trie": ^0.5.0
     graphql-tag: ^2.12.6
-    hoist-non-react-statics: ^3.3.2
-    optimism: ^0.16.1
-    prop-types: ^15.7.2
-    symbol-observable: ^4.0.0
-    ts-invariant: ^0.10.3
+    optimism: ^0.18.0
     tslib: ^2.3.0
-    zen-observable-ts: ^1.2.5
   peerDependencies:
-    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
-    graphql-ws: ^5.5.5
-    react: ^16.8.0 || ^17.0.0 || ^18.0.0
+    graphql: ^16.0.0
+    graphql-ws: ^5.5.5 || ^6.0.3
+    react: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+    react-dom: ^17.0.0 || ^18.0.0 || >=19.0.0-rc
+    rxjs: ^7.3.0
     subscriptions-transport-ws: ^0.9.0 || ^0.11.0
   peerDependenciesMeta:
     graphql-ws:
       optional: true
     react:
       optional: true
+    react-dom:
+      optional: true
     subscriptions-transport-ws:
       optional: true
-  checksum: a3c037ef3465cb5d736d8495c9c2dcb9741e39d9c102f147b479af1923c5913f710981a311d1098b9969ebe87769b749c22274decb5977ad0619032e7ac2cf26
+  checksum: 46ab2e676e7e676e03f9eff30a15032f71fc31b0dc4b445df0676357b66c33f5e8dca6ea4bf6fc1ddcc9a9fc81c8df81906b673c47f1be822205c51c16e91840
   languageName: node
   linkType: hard
 
@@ -5863,30 +5862,39 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@wry/context@npm:^0.6.0":
-  version: 0.6.1
-  resolution: "@wry/context@npm:0.6.1::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2F%40wry%2Fcontext%2F-%2Fcontext-0.6.1.tgz"
+"@wry/caches@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@wry/caches@npm:1.0.1"
   dependencies:
     tslib: ^2.3.0
-  checksum: 4187863175061a8f54659f124e3e5c202e010b2b65bf886b4de9777ce8a45cf183b6f6d88f1f537002cbcbea52103a2eadc337d494106490def10acaf9522c5d
+  checksum: 9e89aa8e9e08577b2e4acbe805f406b141ae49c2ac4a2e22acf21fbee68339fa0550e0dee28cf2158799f35bb812326e80212e49e2afd169f39f02ad56ae4ef4
   languageName: node
   linkType: hard
 
-"@wry/equality@npm:^0.5.0":
-  version: 0.5.2
-  resolution: "@wry/equality@npm:0.5.2::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2F%40wry%2Fequality%2F-%2Fequality-0.5.2.tgz"
+"@wry/context@npm:^0.7.0":
+  version: 0.7.4
+  resolution: "@wry/context@npm:0.7.4"
   dependencies:
     tslib: ^2.3.0
-  checksum: 19a01043a0583663924ed9f4ea109818b9b4cb540877ca75ea49545689f54c6bfc69e725a8b3b129a2ac15ea368fd40bbb94c22e7a5e4ec370f7c4697e64b8b1
+  checksum: 9bc8c30a31f9c7d36b616e89daa9280c03d196576a4f9fef800e9bd5de9434ba70216322faeeacc7ef1ab95f59185599d702538114045df729a5ceea50aef4e2
   languageName: node
   linkType: hard
 
-"@wry/trie@npm:^0.3.0":
-  version: 0.3.1
-  resolution: "@wry/trie@npm:0.3.1::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2F%40wry%2Ftrie%2F-%2Ftrie-0.3.1.tgz"
+"@wry/equality@npm:^0.5.6":
+  version: 0.5.7
+  resolution: "@wry/equality@npm:0.5.7"
   dependencies:
     tslib: ^2.3.0
-  checksum: c3f6b200aefc64b5cd9976b7ed0dd22852eb826d835c5dccd3d03ef788d258af50ca64e8de654e5f812134afdb9d5890f334c8de2276d0dca1751785694654f9
+  checksum: 892f262fae362df80f199b12658ea6966949539d4a3a50c1acf00d94a367d673a38f8efa1abcb726ae9e5cc5e62fce50c540c70f797b7c8a2c4308b401dfd903
+  languageName: node
+  linkType: hard
+
+"@wry/trie@npm:^0.5.0":
+  version: 0.5.0
+  resolution: "@wry/trie@npm:0.5.0"
+  dependencies:
+    tslib: ^2.3.0
+  checksum: 92aeea34152bd8485184236fe328d3d05fc98ee3b431d82ee60cf3584dbf68155419c3d65d0ff3731b204ee79c149440a9b7672784a545afddc8d4342fbf21c9
   languageName: node
   linkType: hard
 
@@ -12105,15 +12113,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"hoist-non-react-statics@npm:^3.3.2":
-  version: 3.3.2
-  resolution: "hoist-non-react-statics@npm:3.3.2::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fhoist-non-react-statics%2F-%2Fhoist-non-react-statics-3.3.2.tgz"
-  dependencies:
-    react-is: ^16.7.0
-  checksum: b1538270429b13901ee586aa44f4cc3ecd8831c061d06cb8322e50ea17b3f5ce4d0e2e66394761e6c8e152cd8c34fb3b4b690116c6ce2bd45b18c746516cb9e8
-  languageName: node
-  linkType: hard
-
 "html-encoding-sniffer@npm:^6.0.0":
   version: 6.0.0
   resolution: "html-encoding-sniffer@npm:6.0.0"
@@ -15065,7 +15064,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "next-real-world@workspace:."
   dependencies:
-    "@apollo/client": ^3.6.9
+    "@apollo/client": 4
     "@graphql-codegen/cli": ^2.7.0
     "@graphql-codegen/typescript": 2.6.0
     "@graphql-codegen/typescript-operations": 2.4.3
@@ -15134,6 +15133,7 @@ __metadata:
     react-dom: 19
     react-hook-form: ^7.33.1
     rimraf: ^3.0.2
+    rxjs: ^7.8.2
     serverless: 2.72.2
     slug: ^5.3.0
     tailwindcss: ^3.1.6
@@ -15931,13 +15931,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"optimism@npm:^0.16.1":
-  version: 0.16.1
-  resolution: "optimism@npm:0.16.1::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Foptimism%2F-%2Foptimism-0.16.1.tgz"
+"optimism@npm:^0.18.0":
+  version: 0.18.1
+  resolution: "optimism@npm:0.18.1"
   dependencies:
-    "@wry/context": ^0.6.0
-    "@wry/trie": ^0.3.0
-  checksum: 7506a3e5e37b8945059ffacd68039e920ad121aab3eeff27483b7a8b594f6f694f2a3b61a198aeecc43b81753d35c8cb32b7f662d2b5e2d2449fe7068da678e1
+    "@wry/caches": ^1.0.0
+    "@wry/context": ^0.7.0
+    "@wry/trie": ^0.5.0
+    tslib: ^2.3.0
+  checksum: bb913a2ac28e3c39fc829bf7b219cc877a085f45f8e5778f25113b251fe26b53a3c2a0e65ce29c3b294dc35e323ede3f52052a3bc2f96caaaec70f9d76cd9622
   languageName: node
   linkType: hard
 
@@ -17103,7 +17105,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"prop-types@npm:^15.7.2, prop-types@npm:^15.8.1":
+"prop-types@npm:^15.8.1":
   version: 15.8.1
   resolution: "prop-types@npm:15.8.1::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fprop-types%2F-%2Fprop-types-15.8.1.tgz"
   dependencies:
@@ -17418,7 +17420,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"react-is@npm:^16.13.1, react-is@npm:^16.7.0":
+"react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Freact-is%2F-%2Freact-is-16.13.1.tgz"
   checksum: f7a19ac3496de32ca9ae12aa030f00f14a3d45374f1ceca0af707c831b2a6098ef0d6bdae51bd437b0a306d7f01d4677fcc8de7c0d331eb47ad0f46130e53c5f
@@ -18064,6 +18066,15 @@ __metadata:
   dependencies:
     tslib: ^2.1.0
   checksum: e034f60805210cce756dd2f49664a8108780b117cf5d0e2281506e9e6387f7b4f1532d974a8c8b09314fa7a16dd2f6cff3462072a5789672b5dcb45c4173f3c6
+  languageName: node
+  linkType: hard
+
+"rxjs@npm:^7.8.2":
+  version: 7.8.2
+  resolution: "rxjs@npm:7.8.2"
+  dependencies:
+    tslib: ^2.1.0
+  checksum: 2f233d7c832a6c255dabe0759014d7d9b1c9f1cb2f2f0d59690fd11c883c9826ea35a51740c06ab45b6ade0d9087bde9192f165cba20b6730d344b831ef80744
   languageName: node
   linkType: hard
 
@@ -19638,13 +19649,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"symbol-observable@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "symbol-observable@npm:4.0.0::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fsymbol-observable%2F-%2Fsymbol-observable-4.0.0.tgz"
-  checksum: 212c7edce6186634d671336a88c0e0bbd626c2ab51ed57498dc90698cce541839a261b969c2a1e8dd43762133d47672e8b62e0b1ce9cf4157934ba45fd172ba8
-  languageName: node
-  linkType: hard
-
 "symbol-tree@npm:^3.2.4":
   version: 3.2.4
   resolution: "symbol-tree@npm:3.2.4"
@@ -20141,15 +20145,6 @@ __metadata:
   peerDependencies:
     typescript: ">=4.8.4"
   checksum: beae72a4fa22a7cc91a8a0f3dfb487d72e30f06ac50ff72f327d061dea2d4940c6451d36578d949caad3893d4d2c7d42d53b7663597ccda54ad32cdb842c3e34
-  languageName: node
-  linkType: hard
-
-"ts-invariant@npm:^0.10.3":
-  version: 0.10.3
-  resolution: "ts-invariant@npm:0.10.3::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fts-invariant%2F-%2Fts-invariant-0.10.3.tgz"
-  dependencies:
-    tslib: ^2.1.0
-  checksum: bb07d56fe4aae69d8860e0301dfdee2d375281159054bc24bf1e49e513fb0835bf7f70a11351344d213a79199c5e695f37ebbf5a447188a377ce0cd81d91ddb5
   languageName: node
   linkType: hard
 
@@ -21748,22 +21743,6 @@ __metadata:
     property-expr: ^2.0.4
     toposort: ^2.0.2
   checksum: 43a16786b47cc910fed4891cebdd89df6d6e31702e9462e8f969c73eac88551ce750732608012201ea6b93802c8847cb0aa27b5d57370640f4ecf30f9f97d4b0
-  languageName: node
-  linkType: hard
-
-"zen-observable-ts@npm:^1.2.5":
-  version: 1.2.5
-  resolution: "zen-observable-ts@npm:1.2.5::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fzen-observable-ts%2F-%2Fzen-observable-ts-1.2.5.tgz"
-  dependencies:
-    zen-observable: 0.8.15
-  checksum: 3b707b7a0239a9bc40f73ba71b27733a689a957c1f364fabb9fa9cbd7d04b7c2faf0d517bf17004e3ed3f4330ac613e84c0d32313e450ddaa046f3350af44541
-  languageName: node
-  linkType: hard
-
-"zen-observable@npm:0.8.15":
-  version: 0.8.15
-  resolution: "zen-observable@npm:0.8.15::__archiveUrl=https%3A%2F%2Fregistry.npmmirror.com%2Fzen-observable%2F-%2Fzen-observable-0.8.15.tgz"
-  checksum: b7289084bc1fc74a559b7259faa23d3214b14b538a8843d2b001a35e27147833f4107590b1b44bf5bc7f6dfe6f488660d3a3725f268e09b3925b3476153b7821
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Summary
- Upgrade @apollo/client from v3 to v4, add rxjs dependency
- Create apollo-shim.ts for graphql-codegen compatibility (hooks moved to @apollo/client/react)
- Migrate ErrorLink to Apollo 4 pattern (CombinedGraphQLErrors)
- Replace deprecated ApolloError with ErrorLike type
- Remove onError/onCompleted from useQuery/useLazyQuery (removed in v4), use useEffect

## Test plan
- [x] Build passes (`yarn build`)
- [x] Unit tests pass (5/6, integration test is Prisma-related)
- [ ] Verify GraphQL queries and mutations work end-to-end
- [ ] Verify error handling works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)